### PR TITLE
Copy customers app in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY manage.py gunicorn-cfg.py requirements.txt .env ./
 COPY app app
 COPY authentication authentication
 COPY core core
+COPY customers customers
 
 RUN pip install -r requirements.txt
 


### PR DESCRIPTION
This will prevent the following error when running the app with docker compose:

```
ModuleNotFoundError: No module named 'customers'
```